### PR TITLE
Refactor to use query instrumenter to allow non-http queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ def create
     variables: query_variables,
     context: {
       # This is the key line: we take the optics_agent passed in from the
-      # Rack environment, give it the query_string, and pass it as context
-      optics_agent: env[:optics_agent].with_document(query_string)
+      # Rack environment and pass it as context
+      optics_agent: env[:optics_agent]
     }
   )
 
@@ -60,6 +60,24 @@ You must:
 2. Register your schema with the `agent.configure` block
 3. Attach the `agent.rack_middleware` to your Rack router
 4. Ensure you pass the `optics_agent` context from the rack environment to your schema execution.
+
+### Non-HTTP queries
+
+If you aren't actually servicing a HTTP/Rack request in executing the query, simply pass:
+
+```ruby
+  context: { optics_agent: :no_rack }
+```
+
+This will mean the query is instrumented without HTTP timings or client versions.
+
+### Skipping queries
+
+If you want to skip a particular query, pass:
+
+```ruby
+  context: { optics_agent: :skip }
+```
 
 ### Configuration
 

--- a/lib/optics-agent/instrumenters/field.rb
+++ b/lib/optics-agent/instrumenters/field.rb
@@ -27,21 +27,9 @@ module OpticsAgent
       def middleware(agent, parent_type, parent_object, field_definition, field_args, query_context, next_middleware)
         agent_context = query_context[:optics_agent]
 
-        unless agent_context
-          agent.warn """No agent passed in graphql context.
-  Ensure you set `context: {optics_agent: env[:optics_agent].with_document(document) }``
-  when executing your graphql query.
-  If you don't want to instrument this query, pass `context: {optics_agent: :skip}`.
-  """
-          # don't warn again for this query
-          agent_context = query_context[:optics_agent] = :skip
-        end
-
         # This happens when an introspection query occurs (reporting schema)
         # Also, people could potentially use it to skip reporting
-        if agent_context == :skip
-          return next_middleware.call
-        end
+        return next_middleware.call if agent_context == :skip
 
         query = agent_context.query
 

--- a/lib/optics-agent/instrumenters/patch-graphql-schema.rb
+++ b/lib/optics-agent/instrumenters/patch-graphql-schema.rb
@@ -4,22 +4,26 @@
 
 require 'graphql'
 require 'optics-agent/instrumenters/field'
+require 'optics-agent/instrumenters/query'
 
 module OpticsAgent::GraphQLSchemaExtensions
   def define(**kwargs, &block)
-    @instrumenter = OpticsAgent::Instrumenters::Field.new
+    @field_instrumenter = OpticsAgent::Instrumenters::Field.new
+    @query_instrumenter = OpticsAgent::Instrumenters::Query.new
 
     class << self
       def _attach_optics_agent(agent)
-        agent.debug "Attaching agent to field instrumenter"
-        @instrumenter.agent = agent
+        agent.debug "Attaching agent to instrumenters"
+        @field_instrumenter.agent = @query_instrumenter.agent = agent
       end
     end
 
-    instrumenter = @instrumenter
+    field_instrumenter = @field_instrumenter
+    query_instrumenter = @query_instrumenter
     super **kwargs do
       instance_eval(&block) if block
-      instrument :field, instrumenter
+      instrument :field, field_instrumenter
+      instrument :query, query_instrumenter
     end
   end
 end

--- a/lib/optics-agent/instrumenters/query.rb
+++ b/lib/optics-agent/instrumenters/query.rb
@@ -1,0 +1,43 @@
+require 'optics-agent/query_context'
+
+module OpticsAgent
+  module Instrumenters
+    class Query
+      attr_accessor :agent
+
+      def before_query(query)
+        return unless @agent
+        query_context = query.context[:optics_agent]
+        return if query_context == :skip
+
+        @agent.ensure_reporting!
+
+        # the rack request didn't add the agent, maybe there is none?
+        unless query_context
+          @agent.warn """No agent passed in graphql context.
+Ensure you set `context: { optics_agent: env[:optics_agent] }` when executing your graphql query (where `env` is the rack environment).
+If you aren't using the rack middleware, `context: {optics_agent: :no_rack}` to avoid this warning.
+If you don't want to instrument this query, pass `context: {optics_agent: :skip}`.
+  """
+          query_context = :no_rack
+        end
+
+        if query_context == :no_rack
+          query.context[:optics_agent] = QueryContext.new(agent)
+          query_context = query.context[:optics_agent]
+        end
+
+        query_context.with_document(query.query_string)
+      end
+
+      def after_query(query)
+        return unless @agent
+        query_context = query.context[:optics_agent]
+        return if query_context == :skip
+
+        agent.debug { "query_instrumenter: query completed" }
+        query_context.query_finished!
+      end
+    end
+  end
+end

--- a/lib/optics-agent/query_context.rb
+++ b/lib/optics-agent/query_context.rb
@@ -1,0 +1,31 @@
+require 'optics-agent/reporting/query'
+
+class QueryContext
+  attr_reader :agent, :query, :no_rack
+  def initialize(agent, rack_env = false)
+    @agent = agent
+    @query = OpticsAgent::Reporting::Query.new
+    @rack_env = rack_env
+  end
+
+  def with_document(query_string)
+    @query.document = query_string
+    self
+  end
+
+  def query_finished!
+    finish! unless @rack_env
+  end
+
+  def request_finished!
+    finish!
+  end
+
+  private def finish!
+    if (@query.document)
+      @agent.debug { "query_context: Adding a query with #{@query.reports.length} field reports" }
+      @query.finish!
+      @agent.add_query(@query, @rack_env)
+    end
+  end
+end

--- a/lib/optics-agent/reporting/report.rb
+++ b/lib/optics-agent/reporting/report.rb
@@ -52,7 +52,7 @@ module OpticsAgent::Reporting
       agent.send_message('/api/ss/stats', @report)
     end
 
-    def add_query(query, rack_env)
+    def add_query(query, rack_env = nil)
       @report.per_signature[query.signature] ||= StatsPerSignature.new
       signature_stats = @report.per_signature[query.signature]
 


### PR DESCRIPTION
Based on feedback from @keithpitt, it seems desirable to instrument queries that don't come from a rack request (e.g. dehydrating data for a server-rendered page, running queries from worker jobs).

I realised that this isn't too hard to do and has some desirable outcomes:

1. You don't need to call `.with_document(..)` any more (see `README.md` changes).
2. If you forget to set the context, you still get reports/traces, just no HTTP times and a warning.

@zol I'm wondering if we should do a 0.5.0 release with this or let the QA-ed 0.4.x get a little more of a chance first?

Note I haven't yet tested that the traces work visually w/o HTTP info as I need to upgrade my account ;)

cc @pcarrier @n1mmy 