### PR TITLE
Add interface support for schema generation

### DIFF
--- a/lib/optics-agent/reporting/schema.rb
+++ b/lib/optics-agent/reporting/schema.rb
@@ -31,7 +31,7 @@ module OpticsAgent::Reporting
         type = schema.types[type_name]
         next unless type.is_a? GraphQL::ObjectType
 
-        fields = type.fields.values.map do |field|
+        fields = type.all_fields.map do |field|
           Field.new({
             name: field.name,
             # XXX: does this actually work for all types?

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -5,10 +5,15 @@ include OpticsAgent::Reporting
 
 describe Schema do
   it "can collect the correct types from a schema" do
+    address_interface = GraphQL::InterfaceType.define do
+      name 'Address'
+      field :streetOne, types.String
+    end
     person_type = GraphQL::ObjectType.define do
       name 'Person'
       field :firstName, types.String
       field :lastName, types.String
+      interfaces [address_interface]
     end
     query_type = GraphQL::ObjectType.define do
       name 'Query'
@@ -17,6 +22,9 @@ describe Schema do
 
     schema = GraphQL::Schema.define do
       query query_type
+      resolve_type ->(object, context) do
+        # noop
+      end
     end
 
     schema_report = Schema.new(schema).message
@@ -25,7 +33,7 @@ describe Schema do
     expect(type.map &:name).to match_array(['Person', 'Query'])
 
     person_type = type.find { |t| t.name == 'Person' }
-    expect(person_type.field.map &:name).to match_array(['firstName', 'lastName'])
+    expect(person_type.field.map &:name).to match_array(['firstName', 'lastName', 'streetOne'])
 
     firstName_field = person_type.field.find { |f| f.name === 'firstName' }
     expect(firstName_field.returnType).to eq('String')


### PR DESCRIPTION
The current implementation for the schema reporting generator expects types to define all fields at the top level. This may not always be the case when working on types which implement interfaces for some of their fields.

This PR alters the behavior of the schema generator to export any fields the included interfaces define in their respective types. For example, here is a before and after:


### Schema

```ruby
identifiable_interface = GraphQL::InterfaceType.define do
  name 'Identifiable'
  field :login, !types.String
end
user_type = GraphQL::ObjectType.define do
  name 'User'
  global_id_field :id
  interfaces [identifiable_interface]
end
query_type = GraphQL::ObjectType.define do
  name 'Query'
  field :user, user_type
end
```

### Before

```json
{
  "header": {
    "agentVersion": "0"
  },
  "introspectionResult": "",
  "type": [
    {
      "name": "User",
      "field": [
        {
          "name": "id",
          "returnType": "ID!"
        },
      ]
    }
  ]
}
```

### After

```json
{
  "header": {
    "agentVersion": "0"
  },
  "introspectionResult": "",
  "type": [
    {
      "name": "User",
      "field": [
        {
          "name": "id",
          "returnType": "ID!"
        },
        {
          "name": "login",
          "returnType": "String!"
        },
      ]
    }
  ]
}
```