### PR TITLE
Ensure the provided query string is not nil

### DIFF
--- a/lib/optics-agent/instrumenters/query.rb
+++ b/lib/optics-agent/instrumenters/query.rb
@@ -27,7 +27,7 @@ If you don't want to instrument this query, pass `context: {optics_agent: :skip}
           query_context = query.context[:optics_agent]
         end
 
-        query_context.with_document(query.query_string)
+        query_context.with_document(query.document.to_query_string)
       end
 
       def after_query(query)


### PR DESCRIPTION
In our application we found the precompiled query string to not always be present, to ensure the query string is present we had to call `query.document.to_query_string`.