### PR TITLE
Lower Faraday gem requirement

### DIFF
--- a/optics-agent.gemspec
+++ b/optics-agent.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'graphql', '~> 1.1'
   s.add_runtime_dependency 'google-protobuf', '~> 3.2'
-  s.add_runtime_dependency 'faraday', '~> 0.11'
+  s.add_runtime_dependency 'faraday', '~> 0.9.0', '< 0.12'
   s.add_runtime_dependency 'net-http-persistent', '~> 2.0'
   s.add_runtime_dependency 'hitimes', '~> 1.2'
 


### PR DESCRIPTION
Our application heavily relies on faraday and bumping it to 0.11.x required bumping the versions of 4-5 gems which we try not to do unless necessary. I took a look to see if the requirement for faraday could be lowered while still matching the existing `~> 0.11` behavior.

All of the tests pasts when running at `0.9.x`, `0.10.x`, and `0.11x` with no other gems required to be bumped.